### PR TITLE
Fix: typo in examples from ?assertion_factories

### DIFF
--- a/R/06_native_types.R
+++ b/R/06_native_types.R
@@ -75,7 +75,7 @@
 #'
 #' # we can use additional conditions in `...`
 #' Integer(anyNA = FALSE) ? x <- c(1L, NA, 1L)
-#' Integer(anyDuplicated = FALSE) ? x <- c(1L, NA, 1L)
+#' Integer(anyDuplicated = 0L) ? x <- c(1L, NA, 1L)
 #' }
 #'
 #' Integer(2) ? x <- 11:12


### PR DESCRIPTION
Fixes typo in the examples of ?assertion_factories. 
`anyDuplicated` returns namely an integer vector of length 1.
