### PR TITLE
docs: Link to prior art pkgs

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -343,15 +343,16 @@ the most common standard use `?mean` still works even when *{typed}* is attached
 This is inspired in good part by Jim Hester and Gabor Csardi's work and many
 great efforts on static typing, assertions, or annotations in R, in particular: 
 
-* Gabor Csardy's *{argufy}*
-* Richie Cotton's *{assertive}*
-* Tony Fishettti's *{assertr*}
-* Hadley Wickham's *{assertthat}*
-* Michel Lang's *{checkmate}*
-* Joe Thorley's *{checkr}*
-* Joe Thorley's *{chk}*
-* Aviral Goel's *{contractr}*
-* Stefan Bache's *{ensurer}*
-* Brian Lee Yung Rowe's *{lambda.r}*
-* Kun Ren's *{rtype}*
-* Jim Hester's *{types}*
+* Gabor Csardy's [*argufy*](https://github.com/gaborcsardi/argufy)
+* Richie Cotton's [*assertive*](https://bitbucket.org/richierocks/assertive/)
+* Tony Fishettti's [*assertr*](https://github.com/tonyfischetti/assertr)
+* Hadley Wickham's [*assertthat*](https://github.com/hadley/assertthat)
+* Michel Lang's [*checkmate*](https://github.com/mllg/checkmate)
+* Joe Thorley's [*checkr*](https://github.com/poissonconsulting/checkr)
+* Joe Thorley's [*chk*](https://github.com/poissonconsulting/chk/)
+* Aviral Goel's [*contractr*](https://github.com/aviralg/contractr)
+* Stefan Bache's [*ensurer*](https://github.com/smbache/ensurer)
+* Brian Lee Yung Rowe's [*lambda.r*](https://github.com/zatonovo/lambda.r)
+* Kun Ren's [*rtype*](https://github.com/renkun-ken/rtype)
+* Duncan Temple Lang's [*TypeInfo*](https://bioconductor.org/packages/TypeInfo/)
+* Jim Hester's [*types*](https://github.com/jimhester/types)


### PR DESCRIPTION
Fixes https://github.com/moodymudskipper/typed/issues/63 and adds links to all the packages.

I always linked to the respective source code repository, which is more useful and stable (common forges like GitHub or GitLab auto-redirect if a repo got moved) than linking to CRAN (becomes pretty useless once a pkg is removed) or separate documentation websites (they tend to disappear when unmaintained).

I dared to remove the curly brackets around package names, let me know if you'd like me to re-add them.