### PR TITLE
Fix `check_arg` and `declare` to not overwrite value on failed assignment

### DIFF
--- a/R/02_declare.R
+++ b/R/02_declare.R
@@ -46,9 +46,9 @@ check_arg <- function(.arg, .assertion, ..., .bind = FALSE) {
           # browser()
           if (!missing(assigned_value)) {
             # we should catch this error and use `sys.call()` to enrich it
-            val <<- try(ASSERTION_CALL, silent = TRUE)
-            if (inherits(val, "try-error")) {
-              e <- attr(val, "condition")$message
+            val_temp <- try(ASSERTION_CALL, silent = TRUE)
+            if (inherits(val_temp, "try-error")) {
+              e <- attr(val_temp, "condition")$message
               fun_call <- sys.call(-1)
               if(!is.null(fun_call)) {
                 fun_call <- deparse1(fun_call)
@@ -56,6 +56,7 @@ check_arg <- function(.arg, .assertion, ..., .bind = FALSE) {
               }
               stop(e, call. = FALSE)
             }
+            val <<- val_temp
           }
           val
         }
@@ -176,9 +177,9 @@ declare <- function(x, assertion, value, const = FALSE) {
           function(assigned_value) {
             if (!missing(assigned_value)) {
               # we should catch this error and use `sys.call()` to enrich it
-              val <<- try(ASSERTION(assigned_value), silent = TRUE)
-              if(inherits(val, "try-error")) {
-                e <- attr(val, "condition")$message
+              val_temp <- try(ASSERTION(assigned_value), silent = TRUE)
+              if(inherits(val_temp, "try-error")) {
+                e <- attr(val_temp, "condition")$message
                 fun_call <- sys.call(-1)
                 is_eval_call <-
                   is.call(fun_call) && identical(fun_call[[1]], quote(eval)) # nocov
@@ -188,6 +189,7 @@ declare <- function(x, assertion, value, const = FALSE) {
                 }
                 stop(e, call. = FALSE)
               }
+              val <<- val_temp
             }
             val
           }


### PR DESCRIPTION
# Problem

- In `check_arg(.bind=TRUE)`, assignments didn’t update the stored value because the code wrote to the wrong variable.
- In `declare()`, when an assignment failed the stored value was replaced by an error object, so you lost the last good value.

# What this PR changes

- Both functions now validate the new value first.
- If the value passes the check, it replaces the old one.
- If it fails, an error is raised but the old value is kept.

# Example

```R
# declare()
Integer(3) ? y <- 1:3
y <- "a"
print(y)

## Got:
# > print(y)
# [1] "Error : type mismatch\n`typeof(value)`: \033[32m\"character\"\033[39m\n`expected`:      \033[32m\"integer\"\033[39m  \n"
# attr(,"class")
# [1] "try-error"
# attr(,"condition")
# <simpleError: type mismatch
# `typeof(value)`: "character"
# `expected`:      "integer"  >

## Expected:
# > print(y)
# [1] 1 2 3

# check_arg()
f <- function(x) {
  check_arg(x, Double(), .bind = TRUE)
  err <- try(x <- "a", silent = TRUE)
  list(err = inherits(err, "try-error"), x_now = x)
}
f(1)

## Got:
# > f(1)
# $err
# [1] TRUE

# $x_now
# [1] "Error : type mismatch\n`typeof(value)`: \033[32m\"character\"\033[39m\n`expected`:      \033[32m\"double\"\033[39m   \n"
# attr(,"class")
# [1] "try-error"
# attr(,"condition")
# <simpleError: type mismatch
# `typeof(value)`: "character"
# `expected`:      "double"   >

## Excepted:
# > f(1)
# $err
# [1] TRUE

# $x_now
# [1] 1
```